### PR TITLE
Use "Inline Array Annotation" for dependencies

### DIFF
--- a/src/angular-rql-query-generator.js
+++ b/src/angular-rql-query-generator.js
@@ -4,7 +4,7 @@
  * License: GPL-3.0
  */
 angular.module('angular-rql-query-generator', [])
-  .factory('RqlQuery', function($log) {
+  .factory('RqlQuery', ['$log', function($log) {
 
     var SCALAR_OPERATORS = ['eq', 'ne', 'lt', 'gt', 'le', 'ge'];
     var ARRAY_OPERATORS = ['in', 'out'];
@@ -228,4 +228,4 @@ angular.module('angular-rql-query-generator', [])
     }
 
     return Query;
-  });
+  }]);


### PR DESCRIPTION
We've tried to use angular-rql-query-generator library (with minification) in the project but get "Unknown provider" angular error. We also tried to use build minified version using provided "gulp build" task (https://github.com/graviphoton/angular-rql-query-generator/blob/develop/gulp/build.js), but also get the same error:

> Error: [$injector:unpr] Unknown provider: tProvider <- t <- RqlQuery

The reason of this is that current version uses "Implicit annotation" for dependencies and it will break the application after minification.

As described in Angular documentation - [Dependency Injection](https://docs.angularjs.org/guide/di) It's good practice to use "Inline Array Annotation", please check Dependency Annotation section of official documentation.

I've changed dependency annotation to "Inline Array Annotation", please check these small changes.
Best regards